### PR TITLE
Added HTTPConverterTest::createRequestTest

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,7 +11,7 @@
     processIsolation            = "false"
     stopOnFailure               = "false"
     syntaxCheck                 = "false"
-    bootstrap                   = "vendor/autoload.php" >
+    bootstrap                   = "tests/bootstrap.php" >
 
     <testsuites>
         <testsuite name="Test Suite">

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -15,7 +15,8 @@ class Configuration
      */
     public function __construct()
     {
-        include_once (__DIR__ . '/../config/config.php');
+        require (__DIR__ . '/../config/config.php');
         $this->configuration =& $config;
+
     }
 }

--- a/src/HTTPConverter.php
+++ b/src/HTTPConverter.php
@@ -29,7 +29,7 @@ class HTTPConverter
      */
     public function createRequest()
     {
-        $this->request = new Request();
+        return $this->request = new Request();
     }
 
     /**

--- a/src/Request.php
+++ b/src/Request.php
@@ -173,7 +173,7 @@ class Request
      */
     public function initializeSession()
     {
-        session_start();
+        @session_start();
         if (isset($_SESSION)) {
             $this->session = $_SESSION;
             if (empty($this->session)) {

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -2,7 +2,13 @@
 
 class ConfigurationTest extends \PHPUnit_Framework_TestCase
 {
-  public function test()
+  public function test1()
+  {
+    $config = new SkooppaOS\webMVc\Configuration();
+
+    $this->assertEquals('/clock/dataSource/dateFormat',$config->configuration['clock']['urlPathMap']);
+  }
+  public function test2()
   {
     $config = new SkooppaOS\webMVc\Configuration();
 

--- a/tests/HTTPConverterTest.php
+++ b/tests/HTTPConverterTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use SkooppaOS\webMVc\Request;
+use SkooppaOS\webMVc\HTTPConverter;
+
+class HTTPConverterTest extends \PHPUnit_Framework_TestCase
+{
+  public function testCreateRequest()
+  {
+    $httpConverter = new HTTPConverter();
+
+    $_SERVER['REQUEST_METHOD'] = 'GET';
+
+    $_SERVER['REQUEST_URI'] = '/';
+
+    //$_SERVER['REQUEST_URI'] = '/blog/slug/id';
+
+    $request = $httpConverter->createRequest();
+    $this->assertTrue($request instanceof Request);
+  }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+session_start();
+require_once __DIR__.'/../vendor/autoload.php';


### PR DESCRIPTION
Modified HTTPConverter::createRequest to return the request object. This matches what web/app.php has and makes testing a bit easier.

Modified Configuration to use require instead of include_once.  Needed this because multiple test causes the Configuration object to be created multiple times.  The original include_once means that after the first test, the config file would no longer be loaded.  I also changed to require since if the config file cannot be found then the rest of the system won't get very far.

Added tests/bootstrap.php to start the session before tests.   This is currently needed because of the session_start stuff buried in the Request object.  The basic problem is that in a testing environment, output is being sent to the console.  That in turn messes up sessions and cookies etc.  Starting the session at the beginning of the test run works around some of the issues.  Refactoring the Request object will eventually be necessary.

Modified Request to use @session_start to suppress the session already started warning.